### PR TITLE
Use proper hasBlock property instead of has-block

### DIFF
--- a/addon/templates/components/scroll-to.hbs
+++ b/addon/templates/components/scroll-to.hbs
@@ -1,4 +1,4 @@
-{{#unless has-block}}
+{{#unless hasBlock}}
   {{#if tagname}}
     <{{tagName}}>{{label}}</{{tagName}}>
   {{else}}

--- a/app/templates/components/scroll-to.hbs
+++ b/app/templates/components/scroll-to.hbs
@@ -1,4 +1,4 @@
-{{#unless has-block}}
+{{#unless hasBlock}}
   {{#if tagname}}
     <{{tagName}}>{{label}}</{{tagName}}>
   {{else}}


### PR DESCRIPTION
The addon wasn't yielding when used in block form so I found that it's been using the incorrect property to check for block usage.