### PR TITLE
Get target/offset/duration in function instead in didInsertElement so it can update

### DIFF
--- a/addon/components/scroll-to.js
+++ b/addon/components/scroll-to.js
@@ -8,21 +8,25 @@ export default Ember.Component.extend({
   duration: 500,
   didInsertElement() {
     const self = this;
+
+    document.querySelector(`#${this.get("elementId")}`)
+      .addEventListener("click", function () {
+        self.scrollToTarget();
+      });
+  },
+
+  scrollToTarget() {
     const target = this.get("target");
     const offset = this.get("offset");
     const duration = this.get("duration");
+
     if (!target) {
       Ember.Logger.error("Target should be passed");
       return;
     }
-    document.querySelector(`#${this.get("elementId")}`)
-      .addEventListener("click", function () {
-        self.scrollToTarget(target, offset, duration);
-      });
-  },
 
-  scrollToTarget(target, offset, duration) {
     const targetPos = document.querySelector(target).offsetTop + offset;
+
     this.animateScroll(targetPos, duration)
   },
 


### PR DESCRIPTION
Solves this [issue](https://github.com/akshay-kr/ember-scroll-to-target/issues/4):
When changing the variables of the component, it doesn't update when component already rendered.

This is because when only when the component is rendered the variables are set, because all the variables are only set in didInsertElement.